### PR TITLE
fixed convexity test by pre-testing simplicity

### DIFF
--- a/src/Components/UseCases/inputPolygon/Common/ConvexityTest.tsx
+++ b/src/Components/UseCases/inputPolygon/Common/ConvexityTest.tsx
@@ -1,4 +1,75 @@
 import { Vertex } from "../../../GUIElements/Types/Shapes/PolygonGUIProps";
+import { doSegmentsIntersect } from "./Geometry";
+
+/**
+ * @returns -1 if the polygon is negatively oriented (vertices listed anticlockwise), 
+ *          +1 if the polygon is positively oriented (vertices listed clockwise)
+ */
+const testOrientation = ( polygon: Vertex[] ) : number => {
+    const nVertices = polygon.length;
+    const theArea = 0.5*polygon.reduce( 
+        (currentArea: number, vertex: Vertex, i: number) => 
+            currentArea + vertex[0]*polygon[ (i+1) % nVertices ][1] - vertex[1]*polygon[ (i+1) % nVertices ][0],
+        0);
+    return Math.sign(theArea);
+} 
+
+const triangleAreaSign = ( P1: Vertex, P2: Vertex, P3: Vertex ) : number => {
+    const area = 0.5*( P1[0]*P2[1] + P1[1]*P3[0] + P2[0]*P3[1] - ( P2[1]*P3[0] + P1[1]*P2[0] + P1[0]*P3[1]) );
+    return Math.sign(area);
+}
+
+/**
+ * @credits implementing the polygonal simplicity test described in the
+ * following article: http://hera.ugr.es/doi/15026760.pdf pp. 2-3 in attempt to fix
+ * a bug causing the convexity test to fail for some self-intersecting (thus non-simple) polygons.
+ * 
+ * Given how a polygon is created I assume the described condition (i) to be
+ * always satisfied.
+ * 
+ */
+const isSimple = ( polygon: Vertex[] ) : boolean => {
+    const nVertices: number = polygon.length;
+    
+    if( nVertices <= 3 )
+        return true;
+
+    const thePolygon = testOrientation(polygon) > 0 ? polygon : polygon.reverse();
+    let verticesWithinSide: boolean = false;
+
+    /**
+     * Test if at least a vertex of the polygon lays on one of the sides.
+     * @FIXME  replace "doSegmentsIntersect" with a test about parallelism. [Vi->Vk] and [Vi->Vj] 
+     *         obviously intersect at least on {Vi}
+     */
+    for( let i: number=0; !verticesWithinSide && i < nVertices; i++ )
+        for( let k: number=0; !verticesWithinSide && k < polygon.length; k++ ) 
+            if( i !== k && (i+1) % nVertices !== k) {
+                const j: number = (i+1) % nVertices;
+                const Vi = thePolygon[i], Vj = thePolygon[j], Vk=thePolygon[k];
+                verticesWithinSide = verticesWithinSide ||
+                     ( ( Vk[1]-Vi[1] )/( Vk[0]-Vi[0] ) === ( Vj[1]-Vi[1] )/( Vj[0]-Vi[0] ) && doSegmentsIntersect( [Vi, Vk], [Vi, Vj] )) ;            
+            }
+    
+    if( verticesWithinSide )
+        return false;
+
+    /**
+     * Testing if two sides intercept. The test returns true if at least two sides intercept, false otherwise
+     */
+    let test3: boolean = false;
+    for( let i: number = 0; !test3 && i < nVertices; i++ )
+        for( let k:number = 0; !test3 && k < nVertices; k++ ) 
+            if( i !== k && (i+1) % nVertices !== k && (k+1) % nVertices !== i) {
+                const j: number = (i+1) % nVertices;
+                const l: number = (k+1) % nVertices;
+                const Vi = thePolygon[i], Vj = thePolygon[j], Vk=thePolygon[k], Vl=thePolygon[l];
+                test3 = test3 || (( triangleAreaSign(Vk, Vi, Vj) !== triangleAreaSign(Vl, Vi, Vj) )
+                            && ( triangleAreaSign(Vi, Vk, Vl) !== triangleAreaSign(Vj, Vk, Vl) ) )
+            }
+                
+    return !test3;
+}
 
 /**
  * @credits this convexity test is based on the following link: 
@@ -9,12 +80,19 @@ export const isConvex = ( polygon: Vertex[] ) : boolean => {
     if( polygon.length < 3 )
         return false;
     else
-        if( polygon.length == 3 )
+        if( polygon.length === 3 )
             return true;
         else {
             const nVertices: number = polygon.length;
             let res: number = 0;
             let isConvex: boolean = true;
+
+            if( !isSimple(polygon) ) {
+                console.log("Polygon is not simple");
+                return false;
+            } else {
+                console.log("Polygon is simple");
+            }
 
             polygon.forEach( (thisVertex: Vertex, i: number) => {
                 const thisV: Vertex = thisVertex;
@@ -22,7 +100,7 @@ export const isConvex = ( polygon: Vertex[] ) : boolean => {
                 const secondNextV: Vertex =  polygon[(i+2) % nVertices];
                 const v: Vertex = [nextV[0] - thisV[0], nextV[1] - thisV[1]];
 
-                if( i == 0 )
+                if( i === 0 )
                     res = secondNextV[0]*v[1] - secondNextV[1]*v[0] + v[0]*thisV[1] - v[1]*thisV[0];
                 else {
                     const newRes: number = secondNextV[0]*v[1] - secondNextV[1]*v[0] + v[0]*thisV[1] - v[1]*thisV[0];
@@ -34,3 +112,4 @@ export const isConvex = ( polygon: Vertex[] ) : boolean => {
             return isConvex;
         }
 }
+

--- a/src/Components/UseCases/inputPolygon/Common/Geometry.tsx
+++ b/src/Components/UseCases/inputPolygon/Common/Geometry.tsx
@@ -1,0 +1,49 @@
+import { solve2x2System, Matrix2x2, ColumnVector2x1 } from "./SystemSolver";
+import { Vertex } from "../../../GUIElements/Types/Shapes/PolygonGUIProps";
+
+export type Segment =  [
+    Vertex, 
+    Vertex,
+]
+
+const doIntervalsOverlap = ( rangeA: [number, number], rangeB: [number, number] ) : boolean => {
+    return !(rangeB[0] > rangeA[1] || rangeA[0] > rangeB[1]);
+}
+
+/**
+ * @FIXME when two segments are parallel but do not intersect, the test returns true
+ */
+export const doSegmentsIntersect = ( segmA: Segment, segmB: Segment ) : boolean => {
+    const A: Matrix2x2 = [ 
+        [ segmA[0][0]-segmA[1][0], segmB[1][0]-segmB[0][0] ],
+        [ segmA[0][1]-segmA[1][1], segmB[1][1]-segmB[0][1] ]
+     ];
+
+    const b: ColumnVector2x1 = [
+        segmB[1][0] - segmA[1][0],
+        segmB[1][1] - segmA[1][1]
+       ];
+
+    if( (A[0][0] === A[0][1] && A[0][1] === b[0] && b[0] === 0) || A[1][0] === A[1][1] && A[1][1] === b[1] && b[1] === 0 ) {
+        const xProjectionS1: [number, number] = [segmA[0][0], segmA[1][0]]; // [Xa, Xb]
+        const yProjectionS1: [number, number] = [segmA[0][1], segmA[1][1]]; // [Ya, Yb]
+
+        const xProjectionS2: [number, number] = [segmB[0][0], segmB[1][0]]; // [Xc, Xd]
+        const yProjectionS2: [number, number] = [segmB[0][1], segmB[1][1]]; // [Yc, Yd]
+
+        if( xProjectionS1[1] === xProjectionS1[0] || xProjectionS2[1] === xProjectionS2[0] )
+            return doIntervalsOverlap( yProjectionS1, yProjectionS2 )
+        else
+            if( yProjectionS1[1] === yProjectionS1[0] || yProjectionS2[1] === yProjectionS2[0] )
+                return doIntervalsOverlap( xProjectionS1, xProjectionS2 )
+            else
+                return doIntervalsOverlap( xProjectionS1, xProjectionS2 ) || doIntervalsOverlap( yProjectionS1, yProjectionS2 );
+    }
+
+    const intersection: [number, number] | null = solve2x2System( A, b );
+
+    if( !!intersection )
+        return (intersection[0] >= 0 && intersection[0] <= 1) && ((intersection[1] >= 0 && intersection[1] <= 1));
+    else
+        return false;
+}

--- a/src/Components/UseCases/inputPolygon/Common/SystemSolver.tsx
+++ b/src/Components/UseCases/inputPolygon/Common/SystemSolver.tsx
@@ -1,0 +1,101 @@
+/**
+ * An implementation of Gauss' method with partial pivoting for solving linear system of equations
+ * based on "Elementi di calcolo numerico: metodi e algoritmi" - M. G. Gasparo, R. Morandi, pp.78, 88
+ * and adapted for the 2x2 case.
+ */
+export type Matrix2x2 = {
+    0: [number, number], 
+    1: [number, number]
+} & Array< Array<number> >
+
+export type ColumnVector2x1 = [number, number];
+
+interface reductionResult {
+    switches: [number, number],
+    aik: [number, number],
+    reducedMatrix: Matrix2x2
+} 
+
+const switchMatrix = ( matrix: Matrix2x2, r: number, c: number ) : Matrix2x2 => {
+    for( let k: number =0; k < matrix[0].length; k++ ) {
+        const tmp : number = matrix[r][k];
+        matrix[r][k] = matrix[c][k];
+        matrix[c][k] = tmp;
+    }
+
+    return matrix;
+}
+
+const findBiggestMultiplier = ( matrix: Matrix2x2, k: number ) : number => {
+    let maximum = matrix[k][k];
+    let maxIdx = k;
+
+    for( let i: number =k+1; i < matrix.length; i++ )
+        if( maximum < matrix[i][k] ) {
+            maximum = matrix[i][k];
+            maxIdx = i;
+        }
+    
+    return maxIdx;
+}
+
+const gaussPartialPivot = ( matrix: Matrix2x2 ) : reductionResult | null => {
+    let switches : [number, number] = [-1, -1];
+    let aikSeq: [number, number] = [-1, -1];
+
+    for( let k: number = 0; k < matrix.length-1; k++  ) {
+        const r = findBiggestMultiplier(matrix, k);
+        
+        if( matrix[r][k] == 0 )
+            return null;
+
+        switches[k] = r;
+        matrix = switchMatrix(matrix, r, k);
+
+        for( let i: number = k+1; i < matrix.length; i++ ) {
+            const aik : number = matrix[i][k]/matrix[k][k];
+            aikSeq[i] = aik;
+            for( let j: number = k+1; j < matrix.length; j++ )
+                matrix[i][j] = matrix[i][j]-aik*matrix[k][j]
+        }
+
+    }
+
+    if( matrix[matrix.length-1][matrix.length-1] === 0 )
+        return null;
+    else
+        return {
+            aik: aikSeq,
+            switches,
+            reducedMatrix: matrix
+        };
+}
+
+const gaussSolve = ( b: ColumnVector2x1, switches: [number, number], aikSeq: [number, number] ) : ColumnVector2x1 => {
+    for( let k: number = 0; k < b.length-1; k++ ) {
+        let tmp : number = b[switches[k]];
+        b[switches[k]] = b[k];
+        b[k] = tmp;
+
+        for( let i: number = k+1; i < b.length; i++ )
+            b[i] = b[i] - aikSeq[i]*b[k];
+    }   
+
+    return b;
+}
+
+const triangularMatrixSolver = (redMatrix: Matrix2x2, b: ColumnVector2x1) : ColumnVector2x1 => {
+    const x2: number = b[1]/redMatrix[redMatrix.length-1][redMatrix.length-1];
+    const x1: number = (b[0]- redMatrix[0][1]*x2)/redMatrix[0][0];
+
+    return [x1, x2];
+}
+
+export const solve2x2System = ( matrix: Matrix2x2, b: [number, number] ) : [number, number] | null => {
+    const rr : reductionResult | null = gaussPartialPivot(matrix);
+    if( !!rr ) {
+        const result : ColumnVector2x1 = gaussSolve( [...b], rr.switches, rr.aik );
+        return triangularMatrixSolver(rr.reducedMatrix, result);
+    } else 
+        return null;
+}

--- a/src/Components/UseCases/inputPolygon/WithMouse/onMouseMove.tsx
+++ b/src/Components/UseCases/inputPolygon/WithMouse/onMouseMove.tsx
@@ -1,11 +1,13 @@
 import Konva from "konva";
 import { setCurrentPoint } from "../Actions/setCurrentPoint";
 import { store } from "../../../Redux/Store/store";
+import { Vertex } from "../../../GUIElements/Types/Shapes/PolygonGUIProps";
 
 export const handleMouseMove = (event: Konva.KonvaEventObject<MouseEvent>) => {
   const mouseCoords = event.target?.getStage()?.getPointerPosition();
+  const lastPoint : Vertex | null | undefined = store.getState().currentPoint;
 
-  if (mouseCoords?.x && mouseCoords?.y)
+  if (mouseCoords?.x && mouseCoords?.y && !!lastPoint)
     if (event.evt.button !== 2 && event.target.getStage())
       store.dispatch(setCurrentPoint([mouseCoords.x, mouseCoords.y]));
 


### PR DESCRIPTION
Added a simplicity test based on [this](http://hera.ugr.es/doi/15026760.pdf) article, to be performed before running the convexity test that is now in place. In fact, that one is guaranteed to work only for simple polygons and could fail for some complex/self-intersecting ones, like the star example.