### PR TITLE
fixed a bug causing nodes not to be popped correctly

### DIFF
--- a/src/Components/Algorithms/BFS.tsx
+++ b/src/Components/Algorithms/BFS.tsx
@@ -40,10 +40,10 @@ const _BFS = ( problem: Problem ) : Action[] | undefined => {
                     if( typeof store.getState().explored![toString(nextNode.state)] === "undefined" 
                             && !store.getState().frontier!.contains(nextNode) ) {
 
-                        if( problem.goalTest( poppedNode.state ) ) {
+                        if( problem.goalTest( nextNode.state ) ) {
     
                             const solution: Action[] = [];
-                            let theNode: Node | null | undefined = poppedNode;
+                            let theNode: Node | null | undefined = nextNode;
                             while( theNode !== null ) {
                                 solution.splice( 0, 0, theNode!.action );
                                 theNode = theNode!.parent;

--- a/src/Components/Algorithms/Common/Problem/Structures/FIFOFrontier.tsx
+++ b/src/Components/Algorithms/Common/Problem/Structures/FIFOFrontier.tsx
@@ -13,7 +13,7 @@ export class FIFOFrontier implements Frontier {
     }
 
     getFirst = () : Node | undefined => {
-        const poppedNode: Node | undefined = this.queue.pop();
+        const poppedNode: Node | undefined = this.queue.shift();
         return poppedNode;
     }
 
@@ -22,7 +22,7 @@ export class FIFOFrontier implements Frontier {
     } 
 
     push = (node: Node) : Array<Node> => {
-        this.queue.splice(0,0,node);
+        this.queue.push(node);
         return this.queue;
     }
 

--- a/src/Components/Algorithms/Common/Problem/Types/Problem.tsx
+++ b/src/Components/Algorithms/Common/Problem/Types/Problem.tsx
@@ -53,16 +53,16 @@ const _popFrontier = ( queue: Array<Node> ): ReduxAction => {
 }
 
 export const popFrontier = () => ( dispatch: Dispatch<ReduxAction>, getState: ()=> ReduxState ) => {
-        const newFrontierQ: Array<Node> = [...getState().frontier!.queue];
+        const frontier: Frontier | null | undefined = getState().frontier;
     
-        if( newFrontierQ.length <= 0 )
+        if( !frontier || frontier?.isEmpty() )
             return null;
         else {
-            const poppedNode: Node | null | undefined = newFrontierQ.pop();
-            if( poppedNode === null || poppedNode === undefined )
+            const poppedNode: Node | null | undefined = frontier.getFirst();
+            if( !poppedNode )
                 return;
             else {
-                dispatch( _popFrontier( newFrontierQ ) );
+                dispatch( _popFrontier( frontier.queue.slice() ) );
                 return poppedNode;
             }
         }

--- a/src/Components/UseCases/RunAlgorithms/AlgorithmsSelector.tsx
+++ b/src/Components/UseCases/RunAlgorithms/AlgorithmsSelector.tsx
@@ -91,6 +91,7 @@ const AlgorithmsSelector: React.FC<AlgorithmsSelectorProps> = ({ usageMode, poly
                         label="Verbose mode"
                         color="dark"
                         radius="xs"
+                        checked={options.verbose}
                         onChange={(event: React.ChangeEvent<Element & { checked: boolean }>) => {
                             updateOptions( {...options, verbose: event.currentTarget.checked} )
                         }}

--- a/src/Components/UseCases/RunAlgorithms/ViewSolution/RenderExplored.tsx
+++ b/src/Components/UseCases/RunAlgorithms/ViewSolution/RenderExplored.tsx
@@ -32,8 +32,8 @@ const RenderExplored: React.FC<RenderExploredProps> = ({ explored, options }) =>
                                     .map( (coordinate: string) : number => parseFloat(coordinate) )
 
                     return <Arrow points={pt}
-                            fill="rgba(0,128,128, .3)"
-                            stroke="rgba(0,128,128, .3)"
+                            fill="rgba(0,128,128, .15)"
+                            stroke="rgba(0,128,128, .15)"
                             strokeWidth={1}
                             tension={1}
                             lineCap="round"


### PR DESCRIPTION
1. Replaced queue.pop with queue.shift
2. Replaced queue.slice with queue.push
3. Fixed incorrect goal testing
4. Now verbose mode displays the correct currently selected value