### PR TITLE
Fixed bug with visibility map and start-destination points

### DIFF
--- a/src/Components/UseCases/PointInPolygon/pointInPolygon.tsx
+++ b/src/Components/UseCases/PointInPolygon/pointInPolygon.tsx
@@ -12,8 +12,6 @@ import { Point } from "../../GUIElements/Types/Shapes/Point";
 export const pointInPolygon = ( point: Point, polygon: Polygon ) : boolean => {
     const verticesCount: number = polygon.vertices.length;
 
-    console.log("Producing point in polygon");
-
     const obstacles: Segment[] = 
         polygon.vertices.map(
             (vertex: Vertex, i: number): Segment => {
@@ -41,7 +39,6 @@ export const pointInPolygon = ( point: Point, polygon: Polygon ) : boolean => {
                     x: (obstacle[0][0]+obstacle[1][0])/2,
                     y: (obstacle[0][1]+obstacle[1][1])/2,
                 } );
-                console.log(obstaclesIntersections);
 
                 pointInside = pointInside && 
                                obstaclesIntersections!.length <= 1;


### PR DESCRIPTION
Fixed a bug that would cause visibility map not to update correctly when start or destination point matched a vertex of a polygon that was transformed.